### PR TITLE
Slow Pinging on Map View During Off Hours

### DIFF
--- a/Vandy Vans/Vandy Vans/VVMapViewController.m
+++ b/Vandy Vans/Vandy Vans/VVMapViewController.m
@@ -202,9 +202,9 @@ static NSTimeInterval const kNonHoursUpdateInterval = 15.0;
             [self.vanMapView removeAnnotations:self.vanAnnotations];
             self.vanAnnotations = nil;
         }
-        if(vansWereRunning)
+        if (vansWereRunning)
             [[VVAlertBuilder vansNotRunningAlertWithDelegate:self] show];
-        if([self.updateTimer timeInterval] != kNonHoursUpdateInterval) {
+        if ([self.updateTimer timeInterval] != kNonHoursUpdateInterval) {
             [self.updateTimer invalidate];
             self.updateTimer = nil;
             [self scheduleUpdateTimerForNonHours];


### PR DESCRIPTION
Prevented the alert from happening multiple times on the livemap. Additionally, invalidated and nullified the timer if it transfers from between one time period to another and restarts the timer with a slower interval if it is off hours.

This should resolve #25 - @sethfri looking all right?  
